### PR TITLE
Fix/huggingface cache permission

### DIFF
--- a/prospect/Dockerfile
+++ b/prospect/Dockerfile
@@ -33,6 +33,10 @@ COPY . .
 RUN mkdir -p /app/data /app/logs /app/harvester_output && \
     chown -R appuser:appuser /app
 
+# Create and permission Hugging Face cache directory
+RUN mkdir -p /app/.cache/huggingface/hub /app/.cache/huggingface_cache && \
+    chown -R appuser:appuser /app/.cache
+
 # MCP Server target
 FROM base AS mcp-server
 


### PR DESCRIPTION
Fix: Create Hugging Face cache directory in Dockerfile

Modifies the prospect/Dockerfile to explicitly create the /app/.cache/huggingface/hub
and /app/.cache/huggingface_cache directories and sets their ownership
to appuser:appuser. This is done before you switch to appuser.

This change addresses an issue where Hugging Face libraries (specifically
sentence-transformers) would fail to create or write to their cache
directory, resulting in an error like:
'Could not create or set writable cache directory /app/.cache/huggingface_cache: [Errno 2] No such file or directory'

Testing of this change by rebuilding the Docker image was unfortunately
prevented by 'No space left on device' errors in the execution
environment. However, this modification implements the standard best
practice for resolving such cache permission issues in Dockerized
applications.