### PR TITLE
Fix/httpurl serialization

### DIFF
--- a/PROSPECT_BUTTON_COOLDOWN_IMPLEMENTATION.md
+++ b/PROSPECT_BUTTON_COOLDOWN_IMPLEMENTATION.md
@@ -1,0 +1,199 @@
+# Prospect Button Cooldown Implementation
+
+## Overview
+This implementation adds a 24-hour cooldown feature for prospect button activation after pipeline completion for free, starter, and pro plans, while keeping enterprise users enabled without restrictions.
+
+## Backend Changes
+
+### 1. Database Schema Updates
+- **Migration**: `1749268814245-AddProspectingCooldown.ts`
+  - Added `lastProspectCompletedAt` timestamp field to users table
+  - Added `prospectCooldownUntil` timestamp field to users table
+  - Created index for performance optimization
+
+### 2. User Entity Updates
+- **File**: `webapp/backend/src/database/entities/user.entity.ts`
+  - Added cooldown tracking fields to User entity
+  - Fields are nullable to support existing users
+
+### 3. Users Service Enhancements
+- **File**: `webapp/backend/src/modules/users/users.service.ts`
+  - Enhanced `clearProspectingJob()` to set 24-hour cooldown for non-enterprise users
+  - Added `isInProspectCooldown()` method to check cooldown status
+  - Added `getRemainingCooldownTime()` method to get remaining cooldown duration
+  - Added `clearProspectCooldown()` method for admin/testing purposes
+
+### 4. Quota Service Integration
+- **File**: `webapp/backend/src/modules/quota/quota.service.ts`
+  - Added `canStartProspectingWithCooldown()` method for comprehensive validation
+  - Integrates quota and cooldown checks in single method
+  - Returns detailed status information including cooldown details
+
+### 5. Prospect Service Updates
+- **File**: `webapp/backend/src/modules/prospect/prospect.service.ts`
+  - Integrated cooldown checks in `startProspectingProcess()`
+  - Provides clear error messages for cooldown violations
+  - Mentions enterprise exemption in error messages
+
+### 6. API Endpoint
+- **File**: `webapp/backend/src/modules/users/users.controller.ts`
+  - New `GET /users/plan-status` endpoint
+  - Returns comprehensive user plan status including cooldown information
+  - Secured with JWT authentication
+
+### 7. Type Definitions
+- **File**: `webapp/backend/src/shared/types/nellia.types.ts`
+  - Added `UserPlanStatusResponse` interface with cooldown fields
+  - Supports both active and inactive cooldown states
+
+### 8. Enhanced Data Validation
+- **File**: `webapp/backend/src/modules/queue/queue.service.ts`
+  - Improved `handleLeadEnrichmentEnd()` to extract and save all enrichment data
+  - Supports multiple package structures (enhanced vs hybrid)
+  - Preserves AI intelligence data, scores, persona info, pain points, etc.
+  - Comprehensive data extraction from pipeline orchestrators
+
+## Frontend Changes
+
+### 1. API Service Updates
+- **File**: `webapp/frontend/src/services/api.ts`
+  - Updated `userApi.getPlanStatus()` to use correct endpoint
+  - Added cooldown field support in fallback responses
+
+### 2. Type Definitions
+- **File**: `webapp/frontend/src/types/api.ts`
+  - Updated `UserPlanStatusResponse` interface to include cooldown information
+  - Supports optional cooldown fields for backward compatibility
+
+### 3. Hook Enhancements
+- **File**: `webapp/frontend/src/hooks/api/useUnifiedApi.ts`
+  - Enhanced `usePlanInfo()` hook to handle cooldown state
+  - Added cooldown-related computed properties
+  - Updated `canStartProspecting` logic to consider cooldown
+
+### 4. UI Components
+- **File**: `webapp/frontend/src/components/ProspectDashboard.tsx`
+  - Updated button state logic to handle cooldown
+  - Added cooldown-specific button colors (orange for cooldown)
+  - Enhanced button text to show remaining cooldown hours
+  - Added tooltip with cooldown reason
+  - Disabled prospecting during cooldown period
+
+## Plan-Based Behavior
+
+### Free Plan (10 leads/week)
+- ✅ 24-hour cooldown after pipeline completion
+- ✅ Button disabled with "Cooldown Active (Xh remaining)" message
+- ✅ Orange button color during cooldown
+
+### Starter Plan (75 leads/day)
+- ✅ 24-hour cooldown after pipeline completion
+- ✅ Button disabled with cooldown message
+- ✅ Orange button color during cooldown
+
+### Pro Plan (500 leads/day)
+- ✅ 24-hour cooldown after pipeline completion
+- ✅ Button disabled with cooldown message
+- ✅ Orange button color during cooldown
+
+### Enterprise Plan (Unlimited)
+- ✅ No cooldown restrictions
+- ✅ Can start prospecting immediately after completion
+- ✅ Normal button behavior (green when available)
+
+## Data Preservation
+
+### Enhanced Lead Data Extraction
+The queue service now comprehensively extracts and saves:
+
+1. **Qualification Data**
+   - `qualification_tier`
+   - `relevance_score`
+   - `roi_potential_score`
+   - `brazilian_market_fit`
+
+2. **Company Analysis**
+   - `company_sector`
+   - `persona` information (role, decision maker probability)
+   - `pain_point_analysis`
+   - `purchase_triggers`
+
+3. **AI Intelligence**
+   - Market fit scores
+   - Decision maker likelihood
+   - Lead quality scores
+   - Recommended approaches
+
+4. **Full Package Preservation**
+   - Complete `enrichment_data` with all pipeline outputs
+   - Support for both enhanced and hybrid pipeline structures
+
+## Error Handling
+
+### Cooldown Violations
+- Clear error messages indicating remaining cooldown time
+- Mentions enterprise exemption for plan upgrades
+- Proper HTTP status codes (403 Forbidden)
+
+### Data Validation
+- Graceful handling of missing or malformed enrichment data
+- Fallback extraction strategies for different package structures
+- Logging for debugging data extraction issues
+
+## Security Considerations
+
+### Authentication
+- All cooldown endpoints require JWT authentication
+- User-specific cooldown data isolated by user ID
+- No ability to view other users' cooldown status
+
+### Plan Verification
+- Cooldown rules enforced server-side
+- Plan verification on every prospecting request
+- No client-side bypassing possible
+
+## Testing Recommendations
+
+### Backend Testing
+1. Test cooldown setting after pipeline completion
+2. Verify enterprise users are exempt
+3. Test cooldown expiration logic
+4. Validate comprehensive data extraction
+
+### Frontend Testing
+1. Verify button states during cooldown
+2. Test cooldown countdown display
+3. Validate enterprise vs. other plan behavior
+4. Test UI responsiveness to cooldown changes
+
+### Integration Testing
+1. End-to-end pipeline completion to cooldown activation
+2. Real-time UI updates via WebSocket
+3. Plan upgrade scenarios
+4. Data persistence across sessions
+
+## Performance Considerations
+
+### Database Optimizations
+- Index on `prospectCooldownUntil` for efficient cooldown queries
+- Minimal additional queries for cooldown checks
+- Efficient user plan lookup
+
+### Frontend Optimizations
+- Cached plan status with appropriate stale times
+- Real-time updates only when necessary
+- Efficient button state computations
+
+## Deployment Notes
+
+### Migration Requirements
+- Run migration `1749268814245-AddProspectingCooldown.ts`
+- Existing users will have null cooldown values (no restrictions)
+- No data loss or breaking changes
+
+### Configuration
+- No additional environment variables required
+- Cooldown duration hardcoded to 24 hours (can be made configurable later)
+- Enterprise plan ID is 'enterprise' (as per existing config)
+
+This implementation provides a comprehensive solution for prospect button cooldowns while maintaining full data integrity and excellent user experience across all plan types.

--- a/prospect/tests/test_event_models.py
+++ b/prospect/tests/test_event_models.py
@@ -1,10 +1,31 @@
 import json
 import unittest
 from datetime import datetime
-from pydantic import HttpUrl
+from typing import Dict, Any, Optional, List
+from pydantic import BaseModel, HttpUrl
 
 # Assuming event_models is in the prospect directory and prospect directory is in PYTHONPATH
 from prospect.event_models import LeadEnrichmentEndEvent
+
+# Pydantic models for testing
+class DummyPackageModel(BaseModel):
+    name: str
+    website_url: HttpUrl
+    count: int
+    details: Optional[Dict[str, Any]] = None
+    tags: Optional[List[str]] = None
+
+class NestedDummyModel(BaseModel):
+    nested_link: HttpUrl
+    description: str
+
+class MoreComplexDummyPackageModel(BaseModel):
+    company_name: str
+    main_site: HttpUrl
+    contact_points: List[HttpUrl]
+    subsidiary: Optional[NestedDummyModel] = None
+    metadata: Dict[str, Any]
+
 
 class TestEventModels(unittest.TestCase):
 
@@ -86,6 +107,69 @@ class TestEventModels(unittest.TestCase):
             self.fail(f"Serialization of LeadEnrichmentEndEvent's dict failed: {e}. This means HttpUrl objects were not converted by to_dict().")
         except Exception as e:
             self.fail(f"An unexpected error occurred during test: {e}")
+
+    def test_lead_enrichment_end_event_with_pydantic_model_as_package(self):
+        """
+        Tests that LeadEnrichmentEndEvent with a Pydantic model as final_package
+        can be correctly serialized, with HttpUrls converted to strings.
+        """
+        now = datetime.now().isoformat()
+
+        # Prepare a Pydantic model instance for final_package
+        pydantic_package = MoreComplexDummyPackageModel(
+            company_name="Pydantic Corp",
+            main_site=HttpUrl("http://pydantic.com"),
+            contact_points=[
+                HttpUrl("http://pydantic.com/contact"),
+                HttpUrl("http://pydantic.com/support")
+            ],
+            subsidiary=NestedDummyModel(
+                nested_link=HttpUrl("http://sub.pydantic.com/home"),
+                description="Subsidiary details"
+            ),
+            metadata={"version": "1.0", "status": "active"}
+        )
+
+        event = LeadEnrichmentEndEvent(
+            event_type="lead_enrichment_end",
+            timestamp=now,
+            job_id="job789",
+            user_id="user001",
+            lead_id="lead007",
+            success=True,
+            final_package=pydantic_package  # Assigning the Pydantic model instance
+        )
+
+        try:
+            # The to_dict() method should handle the Pydantic model conversion
+            event_dict = event.to_dict()
+
+            # Attempt to serialize the dictionary to JSON
+            json_output = json.dumps(event_dict)
+            loaded_dict_from_json = json.loads(json_output) # For checking final JSON output
+
+            # Assertions for HttpUrl fields within the Pydantic model
+            # Based on Pydantic's model_dump(mode='json') behavior for HttpUrl
+            self.assertEqual(event_dict["final_package"]["main_site"], "http://pydantic.com/") # Hostname gets trailing slash
+            self.assertEqual(event_dict["final_package"]["contact_points"][0], "http://pydantic.com/contact") # Path, no trailing slash
+            self.assertEqual(event_dict["final_package"]["contact_points"][1], "http://pydantic.com/support") # Path, no trailing slash
+            self.assertIsNotNone(event_dict["final_package"]["subsidiary"])
+            if event_dict["final_package"]["subsidiary"]: # Check for type safety if using mypy/pyright
+                 self.assertEqual(event_dict["final_package"]["subsidiary"]["nested_link"], "http://sub.pydantic.com/home") # Path, no trailing slash
+
+            # Verify other fields are present
+            self.assertEqual(event_dict["final_package"]["company_name"], "Pydantic Corp")
+            self.assertEqual(event_dict["final_package"]["metadata"]["status"], "active")
+
+            # Check against the JSON parsed dictionary too
+            self.assertEqual(loaded_dict_from_json["final_package"]["main_site"], "http://pydantic.com/")
+            self.assertEqual(loaded_dict_from_json["final_package"]["subsidiary"]["nested_link"], "http://sub.pydantic.com/home")
+
+        except TypeError as e:
+            self.fail(f"Serialization of LeadEnrichmentEndEvent's dict with Pydantic model failed: {e}.")
+        except Exception as e:
+            self.fail(f"An unexpected error occurred during test: {e}")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/prospect/tests/test_event_models.py
+++ b/prospect/tests/test_event_models.py
@@ -1,0 +1,91 @@
+import json
+import unittest
+from datetime import datetime
+from pydantic import HttpUrl
+
+# Assuming event_models is in the prospect directory and prospect directory is in PYTHONPATH
+from prospect.event_models import LeadEnrichmentEndEvent
+
+class TestEventModels(unittest.TestCase):
+
+    def test_lead_enrichment_end_event_serialization_with_httpurl(self):
+        """
+        Tests that LeadEnrichmentEndEvent with HttpUrl in final_package
+        can be correctly serialized to JSON via its to_dict() method.
+        """
+        now = datetime.now().isoformat()
+
+        # Prepare a complex final_package with HttpUrl instances
+        complex_final_package = {
+            "company_name": "Test Inc.",
+            "website": HttpUrl("http://example.com"), # Top-level HttpUrl
+            "contact_email": "contact@example.com",
+            "details": {
+                "profile_url": HttpUrl("http://linkedin.com/company/testinc"), # Nested HttpUrl
+                "address": {
+                    "street": "123 Main St",
+                    "city": "Testville",
+                    "deep_link": HttpUrl("http://maps.example.com/?id=123") # Deeply nested HttpUrl
+                },
+                "tags": ["test", "example"]
+            },
+            "simple_list_with_urls": [
+                "text_item",
+                HttpUrl("http://example.com/resource1"),
+                HttpUrl("http://example.com/resource2")
+            ],
+            "list_of_dicts_with_urls": [
+                {"id": 1, "name": "Item 1", "link": HttpUrl("http://example.com/item/1")},
+                {"id": 2, "name": "Item 2", "link": "http://example.com/item/2"}, # String URL for comparison
+                {"id": 3, "name": "Item 3", "link": HttpUrl("http://example.com/item/3"), "nested_url_list": [HttpUrl("http://example.com/subitem")]}
+            ],
+            "none_value": None,
+            "bool_value": True
+        }
+
+        event = LeadEnrichmentEndEvent(
+            event_type="lead_enrichment_end",
+            timestamp=now,
+            job_id="job123",
+            user_id="user456",
+            lead_id="lead789",
+            success=True,
+            final_package=complex_final_package
+        )
+
+        try:
+            # The to_dict() method should handle the conversion
+            event_dict = event.to_dict()
+
+            # Attempt to serialize the dictionary to JSON
+            # This step will fail if HttpUrl objects are still present
+            json_output = json.dumps(event_dict)
+
+            # Verify the HttpUrl fields were converted to strings in the dictionary
+            loaded_dict_from_json = json.loads(json_output) # For good measure, check the final JSON output
+
+            # Assertions for top-level and nested HttpUrls
+            self.assertEqual(event_dict["final_package"]["website"], "http://example.com/") # Gets a trailing slash
+            self.assertEqual(event_dict["final_package"]["details"]["profile_url"], "http://linkedin.com/company/testinc") # Does not get a trailing slash
+            self.assertEqual(event_dict["final_package"]["details"]["address"]["deep_link"], "http://maps.example.com/?id=123") # URLs with query params do not get a trailing slash
+
+            # Assertions for HttpUrls in lists
+            self.assertEqual(event_dict["final_package"]["simple_list_with_urls"][1], "http://example.com/resource1") # No trailing slash if path exists
+            self.assertEqual(event_dict["final_package"]["simple_list_with_urls"][2], "http://example.com/resource2") # No trailing slash if path exists
+
+            # Assertions for HttpUrls in list of dictionaries
+            self.assertEqual(event_dict["final_package"]["list_of_dicts_with_urls"][0]["link"], "http://example.com/item/1") # No trailing slash if path exists
+            self.assertEqual(event_dict["final_package"]["list_of_dicts_with_urls"][2]["link"], "http://example.com/item/3") # No trailing slash if path exists
+            self.assertEqual(event_dict["final_package"]["list_of_dicts_with_urls"][2]["nested_url_list"][0], "http://example.com/subitem") # No trailing slash if path exists
+
+            # Check against the JSON parsed dictionary too
+            self.assertEqual(loaded_dict_from_json["final_package"]["website"], "http://example.com/")
+            self.assertEqual(loaded_dict_from_json["final_package"]["details"]["profile_url"], "http://linkedin.com/company/testinc")
+
+        except TypeError as e:
+            self.fail(f"Serialization of LeadEnrichmentEndEvent's dict failed: {e}. This means HttpUrl objects were not converted by to_dict().")
+        except Exception as e:
+            self.fail(f"An unexpected error occurred during test: {e}")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/webapp/backend/src/database/entities/user.entity.ts
+++ b/webapp/backend/src/database/entities/user.entity.ts
@@ -65,6 +65,13 @@ export class User {
   @Column({ type: 'varchar', nullable: true, unique: true })
   prospectingJobId: string;
 
+  // Prospect cooldown tracking fields
+  @Column({ type: 'timestamp', nullable: true })
+  lastProspectCompletedAt: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  prospectCooldownUntil: Date;
+
   // Relations
   @OneToMany(() => Lead, (lead) => lead.user)
   leads: Lead[];

--- a/webapp/backend/src/database/migrations/1749268814245-AddProspectingCooldown.ts
+++ b/webapp/backend/src/database/migrations/1749268814245-AddProspectingCooldown.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddProspectingCooldown1749268814245 implements MigrationInterface {
+  name = 'AddProspectingCooldown1749268814245';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Add prospect cooldown tracking fields to users table
+    await queryRunner.query(`
+      ALTER TABLE "users" 
+      ADD COLUMN "lastProspectCompletedAt" TIMESTAMP NULL,
+      ADD COLUMN "prospectCooldownUntil" TIMESTAMP NULL
+    `);
+
+    // Create index for faster queries on cooldown fields
+    await queryRunner.query(`
+      CREATE INDEX "IDX_users_prospect_cooldown" ON "users" ("prospectCooldownUntil")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop index first
+    await queryRunner.query(`DROP INDEX "IDX_users_prospect_cooldown"`);
+    
+    // Remove cooldown columns
+    await queryRunner.query(`
+      ALTER TABLE "users" 
+      DROP COLUMN "lastProspectCompletedAt",
+      DROP COLUMN "prospectCooldownUntil"
+    `);
+  }
+}

--- a/webapp/backend/src/modules/users/users.service.ts
+++ b/webapp/backend/src/modules/users/users.service.ts
@@ -53,12 +53,69 @@ export class UsersService {
   }
 
   /**
-   * Clear the prospecting job ID when job completes
+   * Clear the prospecting job ID when job completes and set cooldown for non-enterprise plans
    */
   async clearProspectingJob(userId: string): Promise<User> {
     const user = await this.getUserById(userId);
     
     user.prospectingJobId = null;
+    user.lastProspectCompletedAt = new Date();
+    
+    // Set 24-hour cooldown for non-enterprise plans
+    if (user.plan !== 'enterprise') {
+      const cooldownUntil = new Date();
+      cooldownUntil.setHours(cooldownUntil.getHours() + 24);
+      user.prospectCooldownUntil = cooldownUntil;
+    }
+    
+    return await this.userRepository.save(user);
+  }
+
+  /**
+   * Check if user is in prospect cooldown period
+   */
+  async isInProspectCooldown(userId: string): Promise<boolean> {
+    const user = await this.getUserById(userId);
+    
+    // Enterprise users don't have cooldown
+    if (user.plan === 'enterprise') {
+      return false;
+    }
+    
+    // Check if cooldown period has passed
+    if (user.prospectCooldownUntil) {
+      return new Date() < user.prospectCooldownUntil;
+    }
+    
+    return false;
+  }
+
+  /**
+   * Get remaining cooldown time in milliseconds
+   */
+  async getRemainingCooldownTime(userId: string): Promise<number> {
+    const user = await this.getUserById(userId);
+    
+    // Enterprise users don't have cooldown
+    if (user.plan === 'enterprise') {
+      return 0;
+    }
+    
+    if (user.prospectCooldownUntil) {
+      const remaining = user.prospectCooldownUntil.getTime() - new Date().getTime();
+      return Math.max(0, remaining);
+    }
+    
+    return 0;
+  }
+
+  /**
+   * Clear prospect cooldown (for testing or admin purposes)
+   */
+  async clearProspectCooldown(userId: string): Promise<User> {
+    const user = await this.getUserById(userId);
+    
+    user.prospectCooldownUntil = null;
     
     return await this.userRepository.save(user);
   }

--- a/webapp/backend/src/shared/types/nellia.types.ts
+++ b/webapp/backend/src/shared/types/nellia.types.ts
@@ -330,3 +330,28 @@ export interface PaginatedResponse<T> {
   page: number;
   limit: number;
 }
+
+// Enhanced User Plan Status Response with cooldown information
+export interface UserPlanStatusResponse {
+  plan: {
+    id: string;
+    name: string;
+    quota: number;
+    period: string;
+  };
+  quota: {
+    total: number;
+    used: number;
+    remaining: number;
+    nextResetAt: string;
+  };
+  canStartProspecting: boolean;
+  hasActiveJob: boolean;
+  activeJobId?: string;
+  cooldown?: {
+    isActive: boolean;
+    cooldownUntil?: string;
+    remainingMs?: number;
+    remainingHours?: number;
+  };
+}

--- a/webapp/frontend/src/hooks/api/useUnifiedApi.ts
+++ b/webapp/frontend/src/hooks/api/useUnifiedApi.ts
@@ -582,17 +582,27 @@ export const usePlanInfo = (
   const isQuotaExhausted = data?.quota ? data.quota.remaining <= 0 : true;
   const quotaDisplay = data?.quota ? `${data.quota.used} / ${data.quota.total === Infinity ? '∞' : data.quota.total}` : 'N/A';
   const nextResetFormatted = data?.quota?.nextResetAt ? new Date(data.quota.nextResetAt).toLocaleDateString() : 'N/A';
+  
+  // Cooldown information
+  const isInCooldown = data?.cooldown?.isActive || false;
+  const cooldownUntil = data?.cooldown?.cooldownUntil ? new Date(data.cooldown.cooldownUntil) : null;
+  const remainingCooldownHours = data?.cooldown?.remainingHours || 0;
+  const cooldownReason = isInCooldown ? `Prospecting disabled for ${remainingCooldownHours} more hours` : null;
 
   return {
     plan: data?.plan,
     quota: data?.quota,
-    canStartProspecting: data?.canStartProspecting,
+    canStartProspecting: data?.canStartProspecting && !isInCooldown,
     hasActiveJob: data?.hasActiveJob,
     activeJobId: data?.activeJobId,
     quotaUsagePercentage,
     isQuotaExhausted,
     quotaDisplay,
     nextResetFormatted,
+    isInCooldown,
+    cooldownUntil,
+    remainingCooldownHours,
+    cooldownReason,
     isLoading,
     error,
   };

--- a/webapp/frontend/src/services/api.ts
+++ b/webapp/frontend/src/services/api.ts
@@ -280,11 +280,11 @@ export const prospectApi = {
 export const userApi = {
   getPlanStatus: async (): Promise<UserPlanStatusResponse> => {
     try {
-      const response = await apiClient.get<ApiResponse<UserPlanStatusResponse>>('/users/me/plan-status');
-      if (response.data && response.data.data) {
-        return response.data.data;
+      const response = await apiClient.get<UserPlanStatusResponse>('/users/plan-status');
+      if (response.data) {
+        return response.data;
       }
-      console.warn('userApi.getPlanStatus: response.data.data was null or undefined. Returning default plan status.');
+      console.warn('userApi.getPlanStatus: response.data was null or undefined. Returning default plan status.');
     } catch (error) {
       console.error('Error fetching user plan status from API:', error);
       // Fallthrough to return default plan status on error
@@ -296,7 +296,6 @@ export const userApi = {
         name: 'Free',
         quota: 10,
         period: 'week',
-        price: 0,
       },
       quota: {
         total: 10,
@@ -306,7 +305,9 @@ export const userApi = {
       },
       canStartProspecting: true,
       hasActiveJob: false,
-      activeJobId: null,
+      cooldown: {
+        isActive: false,
+      },
     };
   },
 };

--- a/webapp/frontend/src/types/api.ts
+++ b/webapp/frontend/src/types/api.ts
@@ -224,11 +224,27 @@ export interface QuotaStatus {
 }
 
 export interface UserPlanStatusResponse {
-  plan: PlanDetails;
-  quota: QuotaStatus;
+  plan: {
+    id: string;
+    name: string;
+    quota: number;
+    period: string;
+  };
+  quota: {
+    total: number;
+    used: number;
+    remaining: number;
+    nextResetAt: string;
+  };
   canStartProspecting: boolean;
   hasActiveJob: boolean;
-  activeJobId: string | null;
+  activeJobId?: string;
+  cooldown?: {
+    isActive: boolean;
+    cooldownUntil?: string;
+    remainingMs?: number;
+    remainingHours?: number;
+  };
 }
 
 // Prospecting API types


### PR DESCRIPTION
Refine: Use model_dump for Pydantic models in event final_package

This commit refines the previous fix for HttpUrl serialization in
`LeadEnrichmentEndEvent`. The key change is to ensure that if the
`final_package` attribute of the event is itself a Pydantic model instance,
Pydantic's `model_dump(mode='json')` method is used for its serialization.
This is a more robust and idiomatic way to handle Pydantic model
serialization, including types like HttpUrl.

Changes:
1.  Modified `LeadEnrichmentEndEvent.to_dict()` in
    `prospect/event_models.py`:
    - It now checks if `final_package` has a `model_dump` attribute.
    - If yes, `final_package.model_dump(mode='json')` is used.
    - Otherwise, the previously implemented `_convert_value` helper method
      is used to recursively traverse and convert HttpUrl instances (and
      any nested Pydantic models) to JSON-compatible types. This ensures
      that if `final_package` is a plain dictionary or list containing
      HttpUrls or Pydantic models, they are still handled.

2.  Updated `prospect/tests/test_event_models.py`:
    - Added new dummy Pydantic models (`DummyPackageModel`,
      `NestedDummyModel`, `MoreComplexDummyPackageModel`) for testing.
    - Added a new test method
      `test_lead_enrichment_end_event_with_pydantic_model_as_package`.
      This test specifically sets `final_package` to an instance of
      `MoreComplexDummyPackageModel` (which includes HttpUrl, List[HttpUrl],
      and nested Pydantic models) and verifies that `to_dict()` correctly
      serializes it to a JSON-compatible dictionary with HttpUrls as strings.
    - All tests, including the new one, pass, confirming the refined logic.