### PR TITLE
Feat/seen leads filter

### DIFF
--- a/webapp/backend/src/config/typeorm.config.ts
+++ b/webapp/backend/src/config/typeorm.config.ts
@@ -2,8 +2,10 @@ import { DataSource, DataSourceOptions } from 'typeorm';
 import { Agent } from '../database/entities/agent.entity';
 import { Lead } from '../database/entities/lead.entity';
 import { User } from '../database/entities/user.entity';
+import { UserSeenLead } from '../database/entities/user-seen-lead.entity';
 import { BusinessContextEntity } from '../database/entities/business-context.entity';
 import { ChatMessage } from '../database/entities/chat-message.entity';
+import { UserSeenLeadTable1750270675446 } from "../database/migrations/1750270675446-UserSeenLeadTable";
 
 // Options for AppDataSource
 const appDataSourceOptions: DataSourceOptions = {
@@ -13,14 +15,8 @@ const appDataSourceOptions: DataSourceOptions = {
   username: process.env.DB_USERNAME || 'postgres',
   password: process.env.DB_PASSWORD || 'postgres',
   database: process.env.DB_DATABASE || 'nellia_prospector',
-  entities: [
-    Agent,
-    Lead,
-    User,
-    BusinessContextEntity,
-    ChatMessage
-  ],
-  migrations: ['src/database/migrations/*.ts'],
+  entities: ['src/database/entities/**/*.entity.ts'],
+  migrations: ['src/database/migrations/*.ts', UserSeenLeadTable1750270675446],
   synchronize: false,
   logging: process.env.NODE_ENV === 'development',
   ssl: process.env.NODE_ENV === 'production'
@@ -46,9 +42,10 @@ export const databaseConfig = (configService: any) => { // configService is typi
       Lead,
       User,
       BusinessContextEntity,
-      ChatMessage
+    ChatMessage,
+    UserSeenLead
     ],
-    migrations: ['dist/database/migrations/*.js'],
+    migrations: ['dist/database/migrations/*.js', UserSeenLeadTable1750270675446],
     synchronize: false,
     logging: configService.get('NODE_ENV') === 'development', // No type arguments
     ssl: configService.get('NODE_ENV') === 'production'

--- a/webapp/backend/src/database/entities/user-seen-lead.entity.ts
+++ b/webapp/backend/src/database/entities/user-seen-lead.entity.ts
@@ -1,0 +1,23 @@
+import { Entity, PrimaryColumn, CreateDateColumn, ManyToOne, JoinColumn } from 'typeorm';
+import { User } from './user.entity';
+import { Lead } from './lead.entity';
+
+@Entity('user_seen_leads')
+export class UserSeenLead {
+  @PrimaryColumn('uuid')
+  userId: string;
+
+  @PrimaryColumn('uuid')
+  leadId: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @ManyToOne(() => Lead, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'leadId' })
+  lead: Lead;
+
+  @CreateDateColumn({ type: 'timestamp with time zone' })
+  seenAt: Date;
+}

--- a/webapp/backend/src/database/migrations/1750270675446-UserSeenLeadTable.ts
+++ b/webapp/backend/src/database/migrations/1750270675446-UserSeenLeadTable.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class UserSeenLeadTable1750270675446 implements MigrationInterface {
+    name = 'UserSeenLeadTable1750270675446'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            CREATE TABLE "user_seen_leads" (
+                "userId" uuid NOT NULL,
+                "leadId" uuid NOT NULL,
+                "seenAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                CONSTRAINT "PK_user_seen_leads" PRIMARY KEY ("userId", "leadId"),
+                CONSTRAINT "FK_user_seen_leads_userId" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+                CONSTRAINT "FK_user_seen_leads_leadId" FOREIGN KEY ("leadId") REFERENCES "leads"("id") ON DELETE CASCADE ON UPDATE NO ACTION
+            )
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            DROP TABLE "user_seen_leads"
+        `);
+    }
+
+}

--- a/webapp/backend/src/modules/leads/leads.controller.ts
+++ b/webapp/backend/src/modules/leads/leads.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete, Query } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Param, Delete, Query, BadRequestException } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiQuery, ApiBearerAuth } from '@nestjs/swagger';
 import { LeadsService } from './leads.service';
+import { UserId } from '../auth/user-id.decorator';
 import {
   LeadData,
   CreateLeadDto,
@@ -15,10 +16,16 @@ export class LeadsController {
   constructor(private readonly leadsService: LeadsService) { }
 
   @Get()
-  @ApiOperation({ summary: 'Get all leads with optional filters' })
+  @ApiOperation({ summary: 'Get all leads with optional filters (excludes seen leads for the user)' })
   @ApiResponse({ status: 200, description: 'List of leads with pagination info' })
-  async findAll(@Query() filters?: LeadFilters): Promise<{ data: LeadData[], total: number }> {
-    return this.leadsService.findAll(filters);
+  async findAll(
+    @Query() filters?: LeadFilters,
+    @UserId() userId?: string,
+  ): Promise<{ data: LeadData[], total: number }> {
+    if (!userId) {
+      throw new BadRequestException('User ID is required to fetch leads.');
+    }
+    return this.leadsService.findAll(userId, filters);
   }
 
   @Get(':id')
@@ -66,6 +73,22 @@ export class LeadsController {
   @ApiResponse({ status: 404, description: 'Lead not found' })
   async remove(@Param('id') id: string): Promise<void> {
     return this.leadsService.remove(id);
+  }
+
+  @Post(':id/mark-seen')
+  @ApiOperation({ summary: 'Mark a lead as seen by the current user' })
+  @ApiParam({ name: 'id', description: 'Lead ID' })
+  @ApiResponse({ status: 201, description: 'Lead marked as seen' }) // 201 for resource state change (creation of seen record)
+  @ApiResponse({ status: 400, description: 'Invalid input: User ID or Lead ID missing' })
+  @ApiResponse({ status: 404, description: 'Lead not found or user context issue' })
+  async markLeadAsSeen(
+    @Param('id') leadId: string,
+    @UserId() userId: string,
+  ): Promise<void> {
+    if (!userId || !leadId) {
+        throw new BadRequestException('User ID and Lead ID must be provided.');
+    }
+    return this.leadsService.markAsSeen(userId, leadId);
   }
 
   @Get('stats/summary')

--- a/webapp/backend/src/modules/leads/leads.module.ts
+++ b/webapp/backend/src/modules/leads/leads.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Lead } from '@/database/entities/lead.entity';
+import { UserSeenLead } from '@/database/entities/user-seen-lead.entity';
 import { LeadsService } from './leads.service';
 import { LeadsController } from './leads.controller';
 import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Lead]), AuthModule],
+  imports: [TypeOrmModule.forFeature([Lead, UserSeenLead]), AuthModule],
   providers: [LeadsService],
   controllers: [LeadsController],
   exports: [LeadsService, TypeOrmModule],

--- a/webapp/backend/src/modules/leads/tests/leads.controller.spec.ts
+++ b/webapp/backend/src/modules/leads/tests/leads.controller.spec.ts
@@ -1,0 +1,108 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LeadsController } from '../leads.controller';
+import { LeadsService } from '../leads.service';
+import { UserId } from '../../auth/user-id.decorator'; // Assuming this path is correct
+import { BadRequestException } from '@nestjs/common';
+import { LeadFilters, LeadData } from '@/shared/types/nellia.types'; // Adjust path as needed
+
+// Mock data
+const mockUserId = 'user-test-id';
+const mockLeadId = 'lead-test-id';
+
+const mockLeadData: LeadData = {
+  id: mockLeadId,
+  company_name: 'TestCo',
+  website: 'test.co',
+  relevance_score: 0.7,
+  roi_potential_score: 0.6,
+  qualification_tier: 'HIGH_POTENTIAL' as any, // Cast for simplicity if enums are not directly used in DTOs
+  company_sector: 'Tech',
+  processing_stage: 'PROSPECTING' as any,
+  status: 'NEW' as any,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  // Add other fields from LeadData as needed
+};
+
+describe('LeadsController', () => {
+  let controller: LeadsController;
+  let service: LeadsService;
+
+  // Mock LeadsService
+  const mockLeadsService = {
+    markAsSeen: jest.fn(),
+    findAll: jest.fn(),
+    // Add other methods used by the controller if necessary for other tests
+    findOne: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    updateStage: jest.fn(),
+    remove: jest.fn(),
+    getLeadsStats: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [LeadsController],
+      providers: [
+        {
+          provide: LeadsService,
+          useValue: mockLeadsService,
+        },
+      ],
+    })
+    // Mocking the UserId decorator's behavior for tests
+    // This approach depends on how UserId decorator is implemented (e.g., ExecutionContext)
+    // For simplicity, we can directly mock its resolved value if it's simple enough,
+    // or more robustly, mock parts of the execution context if needed by the decorator.
+    // However, NestJS testing often relies on overriding guards/decorators at module level for e2e,
+    // for unit tests, it's often about ensuring the method is called with params it would receive.
+    // Here, we'll assume the decorator correctly extracts the ID and passes it.
+    .compile();
+
+    controller = module.get<LeadsController>(LeadsController);
+    service = module.get<LeadsService>(LeadsService);
+
+    // Reset mocks before each test
+    mockLeadsService.markAsSeen.mockClear().mockResolvedValue(undefined);
+    mockLeadsService.findAll.mockClear().mockResolvedValue({ data: [mockLeadData], total: 1 });
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('markLeadAsSeen', () => {
+    it('should call leadsService.markAsSeen with correct userId and leadId', async () => {
+      await controller.markLeadAsSeen(mockLeadId, mockUserId);
+      expect(service.markAsSeen).toHaveBeenCalledWith(mockUserId, mockLeadId);
+    });
+
+    it('should throw BadRequestException if userId is missing', async () => {
+      // The decorator or guard should ideally prevent this, but controller has a check.
+      await expect(controller.markLeadAsSeen(mockLeadId, null)).rejects.toThrow(BadRequestException);
+      expect(service.markAsSeen).not.toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException if leadId is missing (controller check)', async () => {
+        // This check is also in the controller for robustness, though typically @Param handles it
+        await expect(controller.markLeadAsSeen(null, mockUserId)).rejects.toThrow(BadRequestException);
+        expect(service.markAsSeen).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findAll', () => {
+    const mockFilters: LeadFilters = { limit: 10, offset: 0 };
+
+    it('should call leadsService.findAll with userId and filters', async () => {
+      const result = await controller.findAll(mockFilters, mockUserId);
+      expect(service.findAll).toHaveBeenCalledWith(mockUserId, mockFilters);
+      expect(result).toEqual({ data: [mockLeadData], total: 1 });
+    });
+
+    it('should throw BadRequestException if userId is missing when calling findAll', async () => {
+      await expect(controller.findAll(mockFilters, null)).rejects.toThrow(BadRequestException);
+      expect(service.findAll).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/webapp/backend/src/modules/leads/tests/leads.service.spec.ts
+++ b/webapp/backend/src/modules/leads/tests/leads.service.spec.ts
@@ -1,0 +1,272 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Logger } from '@nestjs/common';
+
+import { LeadsService } from '../leads.service';
+import { Lead } from '@/database/entities/lead.entity';
+import { UserSeenLead } from '@/database/entities/user-seen-lead.entity';
+import { QualificationTier, ProcessingStage, LeadStatus } from '@/shared/enums/nellia.enums'; // Adjust path as needed
+
+// Mock data and types
+const mockUserId = 'user-test-id';
+const mockLeadId1 = 'lead-test-id-1';
+const mockLeadId2 = 'lead-test-id-2';
+const mockLeadId3 = 'lead-test-id-3';
+
+const mockLead1: Lead = {
+  id: mockLeadId1,
+  company_name: 'TestCo 1',
+  created_at: new Date(),
+  updated_at: new Date(),
+  relevance_score: 0.8,
+  qualification_tier: QualificationTier.HIGH_POTENTIAL,
+  processing_stage: ProcessingStage.PROSPECTING,
+  status: LeadStatus.NEW,
+  // Add other required fields with mock data
+  website: 'http://testco1.com',
+  company_sector: 'Tech',
+  description: 'Description 1',
+  contact_email: 'contact@testco1.com',
+  contact_phone: '1234567890',
+  contact_role: 'CEO',
+  market_region: 'NA',
+  company_size: 100,
+  annual_revenue: 1000000,
+  pain_point_analysis: {},
+  purchase_triggers: [],
+  persona: {},
+  enrichment_data: {},
+  user_search_queries_id: 'query-id-1',
+};
+
+const mockLead2: Lead = {
+  id: mockLeadId2,
+  company_name: 'TestCo 2',
+  created_at: new Date(),
+  updated_at: new Date(),
+  relevance_score: 0.6,
+  qualification_tier: QualificationTier.MEDIUM_POTENTIAL,
+  processing_stage: ProcessingStage.LEAD_QUALIFICATION,
+  status: LeadStatus.CONTACTED,
+  website: 'http://testco2.com',
+  company_sector: 'Finance',
+  description: 'Description 2',
+  contact_email: 'contact@testco2.com',
+  contact_phone: '0987654321',
+  contact_role: 'CTO',
+  market_region: 'EU',
+  company_size: 50,
+  annual_revenue: 500000,
+  pain_point_analysis: {},
+  purchase_triggers: [],
+  persona: {},
+  enrichment_data: {},
+  user_search_queries_id: 'query-id-2',
+};
+
+const mockUserSeenLeadEntry: UserSeenLead = {
+  userId: mockUserId,
+  leadId: mockLeadId1,
+  seenAt: new Date(),
+  user: null, // In unit tests, we might not need full relation objects
+  lead: null,
+};
+
+describe('LeadsService', () => {
+  let service: LeadsService;
+  let leadRepository: Repository<Lead>;
+  let userSeenLeadRepository: Repository<UserSeenLead>;
+
+  // Mock query builder
+  const mockQueryBuilder = {
+    andWhere: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    leftJoinAndSelect: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    skip: jest.fn().mockReturnThis(),
+    take: jest.fn().mockReturnThis(),
+    getManyAndCount: jest.fn(),
+    where: jest.fn().mockReturnThis(), // Added for findOne in markAsSeen
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LeadsService,
+        {
+          provide: getRepositoryToken(Lead),
+          useClass: Repository, // Use actual Repository class for structure, methods will be mocked
+        },
+        {
+          provide: getRepositoryToken(UserSeenLead),
+          useClass: Repository,
+        },
+        // Logger can be mocked if its methods are directly called and need assertion
+        // For now, assuming console logs are sufficient for service's own logging
+      ],
+    }).compile();
+
+    service = module.get<LeadsService>(LeadsService);
+    leadRepository = module.get<Repository<Lead>>(getRepositoryToken(Lead));
+    userSeenLeadRepository = module.get<Repository<UserSeenLead>>(getRepositoryToken(UserSeenLead));
+
+    // Mock specific repository methods
+    jest.spyOn(leadRepository, 'createQueryBuilder').mockReturnValue(mockQueryBuilder as any);
+    jest.spyOn(userSeenLeadRepository, 'findOne').mockResolvedValue(null);
+    jest.spyOn(userSeenLeadRepository, 'create').mockImplementation((dto) => dto as any);
+    jest.spyOn(userSeenLeadRepository, 'save').mockResolvedValue(undefined);
+    jest.spyOn(userSeenLeadRepository, 'find').mockResolvedValue([]);
+
+    // Reset query builder mocks for each test
+    mockQueryBuilder.andWhere.mockClear().mockReturnThis();
+    mockQueryBuilder.select.mockClear().mockReturnThis();
+    mockQueryBuilder.leftJoinAndSelect.mockClear().mockReturnThis();
+    mockQueryBuilder.orderBy.mockClear().mockReturnThis();
+    mockQueryBuilder.skip.mockClear().mockReturnThis();
+    mockQueryBuilder.take.mockClear().mockReturnThis();
+    mockQueryBuilder.getManyAndCount.mockClear();
+    mockQueryBuilder.where.mockClear().mockReturnThis();
+
+    // Spy on logger if needed, e.g., service['logger'].log = jest.fn();
+    // service['logger'] is an instance of Logger, so we can spy on its methods
+    jest.spyOn(service['logger'], 'log').mockImplementation(() => { });
+    jest.spyOn(service['logger'], 'error').mockImplementation(() => { });
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('markAsSeen', () => {
+    it('should create a new UserSeenLead entry if one does not exist', async () => {
+      jest.spyOn(userSeenLeadRepository, 'findOne').mockResolvedValueOnce(null);
+      const createSpy = jest.spyOn(userSeenLeadRepository, 'create');
+      const saveSpy = jest.spyOn(userSeenLeadRepository, 'save').mockResolvedValueOnce(mockUserSeenLeadEntry);
+
+      await service.markAsSeen(mockUserId, mockLeadId1);
+
+      expect(userSeenLeadRepository.findOne).toHaveBeenCalledWith({ where: { userId: mockUserId, leadId: mockLeadId1 } });
+      expect(createSpy).toHaveBeenCalledWith({ userId: mockUserId, leadId: mockLeadId1 });
+      expect(saveSpy).toHaveBeenCalledWith({ userId: mockUserId, leadId: mockLeadId1 });
+      expect(service['logger'].log).toHaveBeenCalledWith(`Lead ${mockLeadId1} marked as seen by user ${mockUserId}`);
+    });
+
+    it('should not create a new UserSeenLead entry if one already exists', async () => {
+      jest.spyOn(userSeenLeadRepository, 'findOne').mockResolvedValueOnce(mockUserSeenLeadEntry);
+      const createSpy = jest.spyOn(userSeenLeadRepository, 'create');
+      const saveSpy = jest.spyOn(userSeenLeadRepository, 'save');
+
+      await service.markAsSeen(mockUserId, mockLeadId1);
+
+      expect(userSeenLeadRepository.findOne).toHaveBeenCalledWith({ where: { userId: mockUserId, leadId: mockLeadId1 } });
+      expect(createSpy).not.toHaveBeenCalled();
+      expect(saveSpy).not.toHaveBeenCalled();
+      // Optionally check for a log message indicating it already exists, if added
+    });
+
+    it('should throw an error if saving fails', async () => {
+      jest.spyOn(userSeenLeadRepository, 'findOne').mockResolvedValueOnce(null);
+      const expectedError = new Error('Save failed');
+      jest.spyOn(userSeenLeadRepository, 'save').mockRejectedValueOnce(expectedError);
+
+      await expect(service.markAsSeen(mockUserId, mockLeadId1)).rejects.toThrow(expectedError);
+      expect(service['logger'].error).toHaveBeenCalledWith(
+        `Error marking lead ${mockLeadId1} as seen for user ${mockUserId}:`,
+        expectedError,
+      );
+    });
+  });
+
+  describe('findAll', () => {
+    const mockLeads = [mockLead1, mockLead2];
+    const mockTotal = mockLeads.length;
+    const mockFilters = { limit: 10, offset: 0 };
+
+    // Helper to mock convertToLeadData as it's a private method called internally
+    // For simplicity, we assume it transforms the lead entity correctly.
+    // If its logic is complex, it should be tested separately or made protected/public for easier testing.
+    const mockLeadDataArray = mockLeads.map(lead => ({ ...lead, id: lead.id, created_at: lead.created_at.toISOString(), updated_at: lead.updated_at.toISOString() }));
+
+
+    beforeEach(() => {
+        // Default mock for getManyAndCount for findAll tests
+        mockQueryBuilder.getManyAndCount.mockResolvedValue([mockLeads, mockTotal]);
+        // Mock convertToLeadData or spy on it
+        // For this test, we'll assume convertToLeadData works as expected
+        // and its output is reflected in what getManyAndCount would effectively return after mapping
+        jest.spyOn(service as any, 'convertToLeadData').mockImplementation(lead => ({
+          ...lead,
+          id: lead.id,
+          created_at: lead.created_at.toISOString(),
+          updated_at: lead.updated_at.toISOString(),
+        }));
+    });
+
+    it('should filter out leads that have been seen by the user', async () => {
+      const seenLeadEntries = [{ leadId: mockLeadId1 }];
+      jest.spyOn(userSeenLeadRepository, 'find').mockResolvedValueOnce(seenLeadEntries as any);
+
+      // Simulate that getManyAndCount returns only lead2 after filtering
+      mockQueryBuilder.getManyAndCount.mockResolvedValueOnce([[mockLead2], 1]);
+       jest.spyOn(service as any, 'convertToLeadData').mockImplementation(lead => ({
+          ...lead,
+          id: lead.id,
+          created_at: lead.created_at.toISOString(),
+          updated_at: lead.updated_at.toISOString(),
+        }));
+
+
+      const result = await service.findAll(mockUserId, mockFilters);
+
+      expect(userSeenLeadRepository.find).toHaveBeenCalledWith({ where: { userId: mockUserId }, select: ['leadId'] });
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith('lead.id NOT IN (:...seenLeadIds)', { seenLeadIds: [mockLeadId1] });
+      expect(result.data.length).toBe(1);
+      expect(result.data[0].id).toBe(mockLeadId2);
+      expect(result.total).toBe(1);
+    });
+
+    it('should return all leads if no leads have been seen by the user', async () => {
+      jest.spyOn(userSeenLeadRepository, 'find').mockResolvedValueOnce([]); // No seen leads
+      mockQueryBuilder.getManyAndCount.mockResolvedValueOnce([mockLeads, mockTotal]); // Return all mock leads
+
+      const result = await service.findAll(mockUserId, mockFilters);
+
+      expect(userSeenLeadRepository.find).toHaveBeenCalledWith({ where: { userId: mockUserId }, select: ['leadId'] });
+      // Ensure andWhere for seenLeadIds is NOT called if seenLeadIds is empty
+      expect(mockQueryBuilder.andWhere).not.toHaveBeenCalledWith('lead.id NOT IN (:...seenLeadIds)', expect.anything());
+      expect(result.data.length).toBe(mockTotal);
+      expect(result.data.map(d => d.id)).toEqual(mockLeads.map(l => l.id));
+      expect(result.total).toBe(mockTotal);
+    });
+
+    it('should correctly apply other filters along with seen leads filtering', async () => {
+      const specificFilters = { ...mockFilters, company_sector: 'Tech' };
+      const seenLeadEntries = [{ leadId: mockLeadId2 }]; // User has seen mockLead2
+      jest.spyOn(userSeenLeadRepository, 'find').mockResolvedValueOnce(seenLeadEntries as any);
+
+      // Query builder should be called with company_sector filter
+      // And it should filter out mockLeadId2. So only mockLead1 (Tech sector) should remain.
+      // If mockLead1 was also seen, then result would be empty.
+      // For this test, assume mockLead1 is in 'Tech' and not seen. mockLead2 is 'Finance' and seen.
+
+      // Simulate getManyAndCount returns only lead1 after all filters
+      mockQueryBuilder.getManyAndCount.mockResolvedValueOnce([[mockLead1], 1]);
+      jest.spyOn(service as any, 'convertToLeadData').mockImplementation(lead => ({
+          ...lead,
+          id: lead.id,
+          created_at: lead.created_at.toISOString(),
+          updated_at: lead.updated_at.toISOString(),
+        }));
+
+      const result = await service.findAll(mockUserId, specificFilters);
+
+      expect(userSeenLeadRepository.find).toHaveBeenCalledWith({ where: { userId: mockUserId }, select: ['leadId'] });
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith('lead.company_sector = :sector', { sector: 'Tech' });
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith('lead.id NOT IN (:...seenLeadIds)', { seenLeadIds: [mockLeadId2] });
+      expect(result.data.length).toBe(1);
+      expect(result.data[0].id).toBe(mockLeadId1);
+      expect(result.total).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
feat: Implement seen leads tracking and filtering

This commit introduces functionality to track leads that have been seen by you and filter them out from subsequent lead list requests.

Key changes:

-   **Database:**
    -   Added a new `UserSeenLead` entity and corresponding `user_seen_leads` table. This table stores `userId`, `leadId`, and `seenAt` timestamps.
    -   A TypeORM migration (`1750270675446-UserSeenLeadTable.ts`) was created to set up this table with appropriate primary and foreign keys.

-   **Backend (webapp/backend):**
    -   **LeadsService:**
        -   Added `markAsSeen(userId, leadId)` method to record when you see a lead. It prevents duplicate entries.
        -   Modified `findAll(userId, filters)` to:
            -   Accept a `userId`.
            -   Query `user_seen_leads` to find leads already seen by you.
            -   Exclude these seen leads from the results returned by `findAll`. The total count also reflects this filtering.
    -   **LeadsController:**
        -   Added a new endpoint `POST /leads/:id/mark-seen` that allows the frontend to notify the backend when a lead is viewed. It uses the `@UserId` decorator to identify you.
        -   Modified the `GET /leads` endpoint to require a `userId` (extracted via `@UserId`) and pass it to the service, enabling per-user filtering of seen leads.
    -   **LeadsModule:**
        -   Updated to include `UserSeenLeadModule` to make its repository available.
    -   **Unit Tests:**
        -   Added comprehensive unit tests for `LeadsService` and `LeadsController` covering the new functionality:
            -   Marking leads as seen.
            -   Ensuring seen leads are filtered from `findAll`.
            -   Correct handling of user and lead IDs.

This feature prevents you from repeatedly being shown the same leads, improving your experience in the lead prospecting workflow.